### PR TITLE
Add routed multi-agent flow, retrieval, metrics, synthetic data, and TTS hooks

### DIFF
--- a/autogen_agents/base_agents.py
+++ b/autogen_agents/base_agents.py
@@ -3,6 +3,8 @@ from autogen import AssistantAgent, UserProxyAgent, GroupChat, GroupChatManager
 # from memory import log_interaction
 from sim_agents import TaskAwareGroupChat, TaskAwareAgent
 from task_classifier import classify
+from retrieval import retrieve_context
+from router import route_query
 
 # ---------------------------------------------------------------------------
 # 1.  SYSTEM MESSAGES
@@ -46,6 +48,53 @@ Only respond to cases that could not be resolved by Level 1 or 2 agents. Apply a
 
 )
 
+BILLING_SYS_MSG = (
+    """
+You are a Billing Specialist Agent.
+Handle disputes, refunds, fees, and billing adjustments with accuracy.
+Ask for clarification if charge details are missing.
+"""
+)
+
+ACCOUNT_SYS_MSG = (
+    """
+You are an Account Specialist Agent.
+Handle account access, password resets, closures, and identity verification steps.
+If policy changes are required, recommend escalation.
+"""
+)
+
+TRANSACTION_SYS_MSG = (
+    """
+You are a Transactions Specialist Agent.
+Handle transfers, deposits, withdrawals, and pending/duplicate transactions.
+Focus on transaction timelines and possible holds.
+"""
+)
+
+COMPLAINT_SYS_MSG = (
+    """
+You are a Complaints & Disputes Specialist Agent.
+Handle formal complaints, escalation requests, and dispute resolution pathways.
+Summarize next steps clearly.
+"""
+)
+
+GENERAL_SYS_MSG = (
+    """
+You are a General Support Specialist Agent.
+Provide product information and handle general inquiries concisely.
+"""
+)
+
+SYNTH_SYS_MSG = (
+    """
+You are a Response Synthesizer.
+Combine specialist responses into a single clear, customer-friendly reply.
+Avoid repetition and keep a professional tone.
+"""
+)
+
 # ---------------------------------------------------------------------------
 # 2.  LLM CONFIG
 # ---------------------------------------------------------------------------
@@ -69,6 +118,19 @@ l2_agent = AssistantAgent("L2_Support", system_message=L2_SYS_MSG,
 l3_agent = AssistantAgent("L3_Expert",  system_message=L3_SYS_MSG,
                           llm_config=get_ollama_config("mistral"))
 
+billing_agent = AssistantAgent("Billing_Specialist", system_message=BILLING_SYS_MSG,
+                               llm_config=get_ollama_config("llama3"))
+account_agent = AssistantAgent("Account_Specialist", system_message=ACCOUNT_SYS_MSG,
+                               llm_config=get_ollama_config("llama3"))
+transaction_agent = AssistantAgent("Transaction_Specialist", system_message=TRANSACTION_SYS_MSG,
+                                   llm_config=get_ollama_config("llama3"))
+complaint_agent = AssistantAgent("Complaint_Specialist", system_message=COMPLAINT_SYS_MSG,
+                                 llm_config=get_ollama_config("llama3"))
+general_agent = AssistantAgent("General_Specialist", system_message=GENERAL_SYS_MSG,
+                               llm_config=get_ollama_config("llama3"))
+synth_agent = AssistantAgent("Response_Synthesizer", system_message=SYNTH_SYS_MSG,
+                             llm_config=get_ollama_config("mistral"))
+
 customer_proxy = UserProxyAgent(
     name="Customer",
     human_input_mode="NEVER",
@@ -82,6 +144,16 @@ L1_WRAPPED = TaskAwareAgent(l1_agent, role="L1", hourly_wage=18.0)
 L2_WRAPPED = TaskAwareAgent(l2_agent, role="L2", hourly_wage=25.0)
 L3_WRAPPED = TaskAwareAgent(l3_agent, role="L3", hourly_wage=40.0)
 
+SPECIALIST_WRAPPED = {
+    "billing": TaskAwareAgent(billing_agent, role="Billing", hourly_wage=22.0),
+    "account": TaskAwareAgent(account_agent, role="Account", hourly_wage=22.0),
+    "transaction": TaskAwareAgent(transaction_agent, role="Transaction", hourly_wage=22.0),
+    "complaint": TaskAwareAgent(complaint_agent, role="Complaint", hourly_wage=24.0),
+    "general": TaskAwareAgent(general_agent, role="General", hourly_wage=20.0),
+}
+
+SYNTH_WRAPPED = TaskAwareAgent(synth_agent, role="Synthesis", hourly_wage=28.0)
+
 # ---------------------------------------------------------------------------
 # 5.  ESCALATION & SUPPORT FLOW
 # ---------------------------------------------------------------------------
@@ -94,27 +166,62 @@ def _needs_escalation(txt: str) -> bool:
     low = txt.lower()
     return any(word in low for word in _ESCALATE_TRIGGERS)
 
-def run_support_flow(user_query: str) -> str:
+def run_support_flow(user_query: str, session_id: str | None = None) -> str:
     """1‑on‑1 tiered support (L1→L2→L3)."""
     task_type, est_sec = classify(user_query)
 
     # --- L1 ---------------------------------------------------------------
-    reply = L1_WRAPPED.handle(user_query, customer_proxy, task_type, est_sec)
+    reply = L1_WRAPPED.handle(
+        user_query,
+        customer_proxy,
+        task_type,
+        est_sec,
+        metadata={
+            "task_type": task_type,
+            "duration_est_sec": est_sec,
+            "session_id": session_id,
+            "route": ["tiered"],
+        },
+    )
     if not _needs_escalation(reply):
         return reply
 
     # --- L2 ---------------------------------------------------------------
-    reply = L2_WRAPPED.handle(user_query, customer_proxy, task_type, int(est_sec * 1.25))
+    reply = L2_WRAPPED.handle(
+        user_query,
+        customer_proxy,
+        task_type,
+        int(est_sec * 1.25),
+        metadata={
+            "task_type": task_type,
+            "duration_est_sec": est_sec,
+            "session_id": session_id,
+            "route": ["tiered"],
+            "escalated_to": "L2",
+        },
+    )
     if not _needs_escalation(reply):
         return reply
 
     # --- L3 ---------------------------------------------------------------
-    return L3_WRAPPED.handle(user_query, customer_proxy, task_type, int(est_sec * 1.5))
+    return L3_WRAPPED.handle(
+        user_query,
+        customer_proxy,
+        task_type,
+        int(est_sec * 1.5),
+        metadata={
+            "task_type": task_type,
+            "duration_est_sec": est_sec,
+            "session_id": session_id,
+            "route": ["tiered"],
+            "escalated_to": "L3",
+        },
+    )
 
 # ---------------------------------------------------------------------------
 # 6.  GROUP‑CHAT FLOW  (uses the same TaskAware cost accounting)
 # ---------------------------------------------------------------------------
-def run_groupchat_flow(user_query: str) -> str:
+def run_groupchat_flow(user_query: str, session_id: str | None = None) -> str:
     task_type, est_sec = classify(user_query)
 
     gc = GroupChat(
@@ -124,4 +231,56 @@ def run_groupchat_flow(user_query: str) -> str:
     )
     manager = GroupChatManager(gc, llm_config=get_ollama_config("mistral"))
     wrapper = TaskAwareGroupChat(manager, role="GroupChat", hourly_wage=28.0)
-    return wrapper.handle(user_query, customer_proxy, task_type, est_sec)
+    return wrapper.handle(
+        user_query,
+        customer_proxy,
+        task_type,
+        est_sec,
+        metadata={"task_type": task_type, "duration_est_sec": est_sec, "session_id": session_id},
+    )
+
+
+def run_routed_support_flow(
+    user_query: str,
+    session_id: str | None = None,
+    use_llm_router: bool = False,
+) -> str:
+    specialists, task_type, est_sec = route_query(
+        user_query,
+        llm_config=get_ollama_config("mistral"),
+        customer_proxy=customer_proxy,
+        use_llm_router=use_llm_router,
+    )
+    context = retrieve_context(user_query, k=3)
+    responses = []
+    for specialist_key in specialists:
+        specialist = SPECIALIST_WRAPPED.get(specialist_key, SPECIALIST_WRAPPED["general"])
+        response = specialist.handle(
+            user_query,
+            customer_proxy,
+            task_type,
+            est_sec,
+            context=context,
+            metadata={
+                "task_type": task_type,
+                "duration_est_sec": est_sec,
+                "route": specialists,
+                "session_id": session_id,
+            },
+        )
+        responses.append((specialist_key, response))
+
+    combined = "\n\n".join([f"{key.title()} Response:\n{resp}" for key, resp in responses])
+    return SYNTH_WRAPPED.handle(
+        combined,
+        customer_proxy,
+        task_type,
+        int(est_sec * 1.1),
+        context=context,
+        metadata={
+            "task_type": task_type,
+            "duration_est_sec": est_sec,
+            "route": specialists,
+            "session_id": session_id,
+        },
+    )

--- a/autogen_agents/main.py
+++ b/autogen_agents/main.py
@@ -1,8 +1,18 @@
 # === main.py ===============================================================
-from simulation_engine import simulate_query_handling
-from base_agents import run_groupchat_flow   # <- already has wrapped agents
+from __future__ import annotations
 
-def _batch_demo() -> None:
+import argparse
+from datetime import datetime
+
+from simulation_engine import simulate_query_handling
+from base_agents import run_groupchat_flow
+from metrics import summarize_logs
+from synthetic_data import generate_queries
+from memory import log_interaction
+from voice import synthesize
+
+def _batch_demo(use_router: bool, use_llm_router: bool, session_id: str | None, voice: bool,
+                tts_cmd: str | None, tts_model: str | None, tts_voice: str | None) -> None:
     print("\n🚀  Running autonomous GroupChat batch …\n")
     questions = [
         "Why was I charged a $15 fee?",
@@ -12,10 +22,25 @@ def _batch_demo() -> None:
     ]
     for i, q in enumerate(questions, 1):
         print(f"\n== Query {i} ==\n")
-        run_groupchat_flow(q)
+        response = run_groupchat_flow(q, session_id=session_id)
+        if voice:
+            audio_path = synthesize(
+                response,
+                filename_stem=f"{session_id or 'batch'}_{i}",
+                model=tts_model,
+                voice=tts_voice,
+                command=tts_cmd,
+            )
+            log_interaction(
+                agent_name="Voice",
+                query=q,
+                response=response,
+                metadata={"session_id": session_id, "tts_path": str(audio_path)},
+            )
     print("\n✅  GroupChat simulation complete!\n")
 
-def _interactive_cli() -> None:
+def _interactive_cli(use_router: bool, use_llm_router: bool, session_id: str | None, voice: bool,
+                     tts_cmd: str | None, tts_model: str | None, tts_voice: str | None) -> None:
     print("\n🗣️  Enter support queries (type 'exit' to quit)\n")
     qid = 1
     while True:
@@ -23,10 +48,88 @@ def _interactive_cli() -> None:
         if text.lower() in {"exit", "quit"}:
             print("👋  Bye!")
             break
-        simulate_query_handling(qid, text)   # uses run_support_flow internally
+        response = simulate_query_handling(
+            qid,
+            text,
+            session_id=session_id,
+            use_router=use_router,
+            use_llm_router=use_llm_router,
+        )
+        if voice:
+            audio_path = synthesize(
+                response,
+                filename_stem=f"{session_id or 'cli'}_{qid}",
+                model=tts_model,
+                voice=tts_voice,
+                command=tts_cmd,
+            )
+            log_interaction(
+                agent_name="Voice",
+                query=text,
+                response=response,
+                metadata={"session_id": session_id, "tts_path": str(audio_path)},
+            )
         qid += 1
 
+
+def _synthetic_demo(count: int, use_router: bool, use_llm_router: bool, session_id: str | None,
+                    voice: bool, tts_cmd: str | None, tts_model: str | None,
+                    tts_voice: str | None) -> None:
+    print("\n🧪  Running synthetic batch …\n")
+    questions = generate_queries(count=count)
+    for i, q in enumerate(questions, 1):
+        response = simulate_query_handling(
+            i,
+            q,
+            session_id=session_id,
+            use_router=use_router,
+            use_llm_router=use_llm_router,
+        )
+        if voice:
+            audio_path = synthesize(
+                response,
+                filename_stem=f"{session_id or 'synthetic'}_{i}",
+                model=tts_model,
+                voice=tts_voice,
+                command=tts_cmd,
+            )
+            log_interaction(
+                agent_name="Voice",
+                query=q,
+                response=response,
+                metadata={"session_id": session_id, "tts_path": str(audio_path)},
+            )
+    print("\n✅  Synthetic simulation complete!\n")
+
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Customer Support Simulator")
+    parser.add_argument("--mode", choices=["cli", "batch", "synthetic"], default="cli")
+    parser.add_argument("--router", action="store_true", help="Enable router-based specialist flow")
+    parser.add_argument("--llm-router", action="store_true", help="Use LLM router instead of rules")
+    parser.add_argument("--session-id", default=None, help="Session identifier for logs")
+    parser.add_argument("--voice", action="store_true", help="Enable TTS output via Chatterbox")
+    parser.add_argument("--tts-cmd", default=None, help="CLI command template for Chatterbox")
+    parser.add_argument("--tts-model", default=None, help="Model name for Chatterbox")
+    parser.add_argument("--tts-voice", default=None, help="Voice name for Chatterbox")
+    parser.add_argument("--synthetic-count", type=int, default=8)
+    parser.add_argument("--metrics", action="store_true", help="Print metrics summary after run")
+    args = parser.parse_args()
+
+    session_id = args.session_id or datetime.utcnow().strftime("%Y%m%d%H%M%S")
+
     print("Customer Support Simulator")
-    mode = input("Choose mode [1] CLI | [2] Batch demo: ").strip()
-    _batch_demo() if mode == "2" else _interactive_cli()
+    if args.mode == "batch":
+        _batch_demo(args.router, args.llm_router, session_id, args.voice,
+                    args.tts_cmd, args.tts_model, args.tts_voice)
+    elif args.mode == "synthetic":
+        _synthetic_demo(args.synthetic_count, args.router, args.llm_router, session_id,
+                        args.voice, args.tts_cmd, args.tts_model, args.tts_voice)
+    else:
+        _interactive_cli(args.router, args.llm_router, session_id, args.voice,
+                         args.tts_cmd, args.tts_model, args.tts_voice)
+
+    if args.metrics:
+        summary = summarize_logs(session_id=session_id)
+        print("\n📊 Metrics Summary")
+        for key, value in summary.items():
+            print(f"- {key}: {value}")

--- a/autogen_agents/memory.py
+++ b/autogen_agents/memory.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 from datetime import datetime
 import json
 from pathlib import Path
+from typing import Any
 
 _LOG_PATH = Path("data/logs")
 _LOG_PATH.mkdir(parents=True, exist_ok=True)
@@ -13,7 +14,8 @@ def log_interaction(agent_name: str,
                     query: str,
                     response: str,
                     escalated_to: str | None = None,
-                    confidence: float | None = None):
+                    confidence: float | None = None,
+                    metadata: dict[str, Any] | None = None):
     record = {
         "ts": datetime.utcnow().isoformat(timespec="seconds") + "Z",
         "query": query,
@@ -21,6 +23,8 @@ def log_interaction(agent_name: str,
         "escalated_to": escalated_to,
         "confidence": confidence,
     }
+    if metadata:
+        record["metadata"] = metadata
     agent_memory[agent_name].append(record)
 
     # append‑only JSONL on disk for long‑running sims

--- a/autogen_agents/metrics.py
+++ b/autogen_agents/metrics.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from statistics import mean
+
+
+def _load_records(log_dir: Path) -> list[dict]:
+    records = []
+    if not log_dir.exists():
+        return records
+    for path in log_dir.glob("*.jsonl"):
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                records.append(json.loads(line))
+    return records
+
+
+def summarize_logs(log_dir: Path | str = "data/logs", session_id: str | None = None) -> dict:
+    log_dir = Path(log_dir)
+    records = _load_records(log_dir)
+    if session_id:
+        records = [
+            record
+            for record in records
+            if record.get("metadata", {}).get("session_id") == session_id
+        ]
+
+    if not records:
+        return {"total_interactions": 0}
+
+    durations = [
+        record.get("metadata", {}).get("actual_sec")
+        for record in records
+        if record.get("metadata", {}).get("actual_sec") is not None
+    ]
+    costs = [
+        record.get("metadata", {}).get("cost")
+        for record in records
+        if record.get("metadata", {}).get("cost") is not None
+    ]
+    escalations = [
+        record
+        for record in records
+        if record.get("metadata", {}).get("escalated_to")
+    ]
+    categories = {}
+    for record in records:
+        task_type = record.get("metadata", {}).get("task_type", "unknown")
+        categories[task_type] = categories.get(task_type, 0) + 1
+
+    return {
+        "total_interactions": len(records),
+        "avg_handle_time_sec": round(mean(durations), 2) if durations else None,
+        "avg_cost": round(mean(costs), 2) if costs else None,
+        "escalations": len(escalations),
+        "task_breakdown": categories,
+    }

--- a/autogen_agents/retrieval.py
+++ b/autogen_agents/retrieval.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+
+from faq_loader import load_faq_database
+
+
+@lru_cache(maxsize=1)
+def _get_faq_db():
+    faq_path = Path(__file__).parent.parent / "data" / "grounding" / "faq.txt"
+    return load_faq_database(faq_path)
+
+
+def retrieve_context(query: str, k: int = 3) -> str:
+    faq_db = _get_faq_db()
+    retrieved_docs = faq_db.similarity_search(query, k=k)
+    return "\n".join([doc.page_content for doc in retrieved_docs])

--- a/autogen_agents/router.py
+++ b/autogen_agents/router.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import json
+import re
+from typing import Iterable
+
+from autogen import AssistantAgent, UserProxyAgent
+from task_classifier import classify
+
+
+ROUTER_SYS_MSG = """
+You are a routing agent for a call center.
+Your job is to decide which specialist agent(s) should handle the user query.
+
+Return JSON with keys:
+- "specialists": list of strings (e.g., "billing", "account", "transaction", "complaint", "general")
+Keep the list short (1-2 items).
+"""
+
+
+def get_router_agent(llm_config) -> AssistantAgent:
+    return AssistantAgent("Router", system_message=ROUTER_SYS_MSG, llm_config=llm_config)
+
+
+def _rule_based_route(task_type: str) -> list[str]:
+    normalized = task_type.lower()
+    if "billing" in normalized:
+        return ["billing"]
+    if "account" in normalized:
+        return ["account"]
+    if "transaction" in normalized:
+        return ["transaction"]
+    if "complaint" in normalized:
+        return ["complaint"]
+    if "product" in normalized or "information" in normalized:
+        return ["general"]
+    return ["general"]
+
+
+def _parse_router_response(raw: str) -> list[str]:
+    try:
+        payload = json.loads(raw)
+        specialists = payload.get("specialists", [])
+        if isinstance(specialists, list):
+            return [str(item).strip().lower() for item in specialists if str(item).strip()]
+    except json.JSONDecodeError:
+        pass
+    match = re.search(r"specialists?:\s*\[([^\]]+)\]", raw, re.IGNORECASE)
+    if match:
+        items = [item.strip(" \"'").lower() for item in match.group(1).split(",")]
+        return [item for item in items if item]
+    return []
+
+
+def route_query(
+    query: str,
+    llm_config: dict,
+    customer_proxy: UserProxyAgent,
+    use_llm_router: bool = False,
+) -> tuple[list[str], str, int]:
+    task_type, est_sec = classify(query)
+    if not use_llm_router:
+        return _rule_based_route(task_type), task_type, est_sec
+
+    router_agent = get_router_agent(llm_config)
+    result = customer_proxy.initiate_chat(
+        message=query,
+        recipient=router_agent,
+        summary_method="last_msg",
+        max_turns=1,
+    )
+    specialists = _parse_router_response(result.summary)
+    if not specialists:
+        specialists = _rule_based_route(task_type)
+    return specialists, task_type, est_sec
+
+
+def normalize_specialists(specialists: Iterable[str]) -> list[str]:
+    return [spec.strip().lower() for spec in specialists if spec.strip()]

--- a/autogen_agents/sim_agents.py
+++ b/autogen_agents/sim_agents.py
@@ -13,7 +13,15 @@ class TaskAwareAgent:
     # ---------------------------------------------------------------------
     # Public helpers -------------------------------------------------------
     # ---------------------------------------------------------------------
-    def handle(self, query: str, customer_proxy, task_type: str, duration_est_sec: int):
+    def handle(
+        self,
+        query: str,
+        customer_proxy,
+        task_type: str,
+        duration_est_sec: int,
+        context: str | None = None,
+        metadata: dict | None = None,
+    ):
         """Send *query* to the wrapped LLM assistant.  We:
         1. Print a small banner so you can watch the sim run.
         2. Time the round‑trip to produce *actual* duration.
@@ -26,7 +34,11 @@ class TaskAwareAgent:
         start_time = datetime.now()
         # We prefix the user query with context only visible to the assistant
         # (makes the prompt a bit richer & lets us see the ETA up front)
-        prompt = f"[{task_type} – est {duration_est_sec}s]\n\n{query}"
+        prompt_parts = [f"[{task_type} – est {duration_est_sec}s]"]
+        if context:
+            prompt_parts.append(f"\n[Retrieved Context]\n{context}")
+        prompt_parts.append(f"\n{query}")
+        prompt = "\n".join(prompt_parts)
         result = customer_proxy.initiate_chat(
             message=prompt,
             recipient=self.agent,
@@ -42,12 +54,19 @@ class TaskAwareAgent:
         # -----------------------------------------------------------------
         # Persist lightweight trace (for dashboards later) -----------------
         # -----------------------------------------------------------------
+        merged_metadata = dict(metadata or {})
+        merged_metadata.update({
+            "role": self.role,
+            "actual_sec": round(actual_sec, 2),
+            "cost": cost,
+        })
         log_interaction(
             agent_name=self.agent.name,
             query=query,
             response=result.summary,
             escalated_to=None,
             confidence=None,
+            metadata=merged_metadata,
         )
 
         return result.summary
@@ -61,13 +80,25 @@ class TaskAwareGroupChat:
         self.role = role
         self.hourly_wage = hourly_wage
 
-    def handle(self, query: str, customer_proxy, task_type: str, duration_est_sec: int):
+    def handle(
+        self,
+        query: str,
+        customer_proxy,
+        task_type: str,
+        duration_est_sec: int,
+        context: str | None = None,
+        metadata: dict | None = None,
+    ):
         print(f"🤝 GroupChat handling task: {task_type} (est {duration_est_sec}s)")
 
         start_time = datetime.now()
+        prompt_parts = [f"[{task_type} – est {duration_est_sec}s]"]
+        if context:
+            prompt_parts.append(f"\n[Retrieved Context]\n{context}")
+        prompt_parts.append(f"\n{query}")
         result = customer_proxy.initiate_chat(
             self.manager,
-            message=f"[{task_type} – est {duration_est_sec}s]\n\n{query}",
+            message="\n".join(prompt_parts),
         )
         end_time = datetime.now()
 
@@ -75,12 +106,19 @@ class TaskAwareGroupChat:
         cost = round(actual_sec / 3600 * self.hourly_wage, 2)
         print(f"💬 GroupChat completed in {actual_sec:.1f}s – cost ${cost:.2f}")
 
+        merged_metadata = dict(metadata or {})
+        merged_metadata.update({
+            "role": self.role,
+            "actual_sec": round(actual_sec, 2),
+            "cost": cost,
+        })
         log_interaction(
             agent_name="GroupChatManager",
             query=query,
             response=result.summary,
             escalated_to=None,
             confidence=None,
+            metadata=merged_metadata,
         )
 
         return result.summary

--- a/autogen_agents/simulation_engine.py
+++ b/autogen_agents/simulation_engine.py
@@ -2,7 +2,7 @@
 import random
 import time
 from datetime import datetime
-from base_agents import run_support_flow
+from base_agents import run_support_flow, run_routed_support_flow
 from faq_loader import load_faq_database
 
 # Load FAQ grounding once globally
@@ -21,7 +21,8 @@ agent_pool = {tier: AGENT_TIERS[tier]["count"] for tier in AGENT_TIERS}
 # Global logs
 call_log = []
 
-def simulate_query_handling(query_id, query_text, complexity="medium"):
+def simulate_query_handling(query_id, query_text, complexity="medium", session_id: str | None = None,
+                            use_router: bool = False, use_llm_router: bool = False):
     start_time = datetime.now()
     print(f"\n Handling Query {query_id}: {query_text} [{complexity}]")
 
@@ -38,8 +39,14 @@ def simulate_query_handling(query_id, query_text, complexity="medium"):
         agent_pool["L1"] -= 1
         print(" Routed to L1 agent...")
         time.sleep(random.gauss(AGENT_TIERS["L1"]["avg_time"], 2))
-        # response = run_support_flow(augmented_query)
-        response = run_support_flow(query_text)
+        if use_router:
+            response = run_routed_support_flow(
+                query_text,
+                session_id=session_id,
+                use_llm_router=use_llm_router,
+            )
+        else:
+            response = run_support_flow(query_text, session_id=session_id)
 
         agent_pool["L1"] += 1
     else:
@@ -53,7 +60,7 @@ def simulate_query_handling(query_id, query_text, complexity="medium"):
             agent_pool["L2"] -= 1
             print(" Escalated to L2 agent...")
             time.sleep(random.gauss(AGENT_TIERS["L2"]["avg_time"], 2))
-            response = run_support_flow(augmented_query)
+            response = run_support_flow(query_text, session_id=session_id)
             agent_pool["L2"] += 1
 
             if "escalate" in response.lower():
@@ -61,7 +68,7 @@ def simulate_query_handling(query_id, query_text, complexity="medium"):
                     agent_pool["L3"] -= 1
                     print("🚨 Escalated to L3 expert...")
                     time.sleep(random.gauss(AGENT_TIERS["L3"]["avg_time"], 2))
-                    response = run_support_flow(augmented_query)
+                    response = run_support_flow(query_text, session_id=session_id)
                     agent_pool["L3"] += 1
                 else:
                     response += "\n[L3 unavailable, please try again later.]"
@@ -74,6 +81,7 @@ def simulate_query_handling(query_id, query_text, complexity="medium"):
     call_log.append({
         "id": query_id,
         "query": query_text,
+        "session_id": session_id,
         "start": start_time,
         "end": end_time,
         "duration": elapsed,

--- a/autogen_agents/synthetic_data.py
+++ b/autogen_agents/synthetic_data.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import random
+
+
+SCENARIOS = {
+    "billing": [
+        "I was charged a {amount} fee I don't recognize.",
+        "My bill increased by {amount} this month. Why?",
+        "Please refund the {amount} overdraft fee.",
+    ],
+    "account": [
+        "I need to reset my password but the link expired.",
+        "Can you close my account and send confirmation?",
+        "My account is locked after too many login attempts.",
+    ],
+    "transaction": [
+        "Why is my transfer pending for {days} days?",
+        "I made a deposit but it hasn't shown up.",
+        "There is a duplicate charge on my card.",
+    ],
+    "complaint": [
+        "I'm unhappy with how my dispute was handled.",
+        "I filed a complaint last week and haven't heard back.",
+        "Your service has been unreliable and I want to escalate.",
+    ],
+    "product info": [
+        "What are the limits on international transfers?",
+        "How does your premium account work?",
+        "Do you offer purchase protection?",
+    ],
+    "sales": [
+        "Can I upgrade to the premium plan?",
+        "I'd like to add another line of service.",
+        "What promotions are available this month?",
+    ],
+}
+
+
+def generate_queries(count: int = 10, seed: int | None = None) -> list[str]:
+    rng = random.Random(seed)
+    categories = list(SCENARIOS.keys())
+    queries = []
+    for _ in range(count):
+        category = rng.choice(categories)
+        template = rng.choice(SCENARIOS[category])
+        query = template.format(
+            amount=rng.choice(["$15", "$32", "$120"]),
+            days=rng.choice(["2", "5", "7"]),
+        )
+        queries.append(query)
+    return queries

--- a/autogen_agents/voice/__init__.py
+++ b/autogen_agents/voice/__init__.py
@@ -1,0 +1,3 @@
+from .tts import synthesize
+
+__all__ = ["synthesize"]

--- a/autogen_agents/voice/tts.py
+++ b/autogen_agents/voice/tts.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import importlib
+import os
+from pathlib import Path
+import shlex
+import subprocess
+from typing import Optional
+
+
+def _ensure_output_path(output_dir: Path, stem: str) -> Path:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    return output_dir / f"{stem}.wav"
+
+
+def synthesize(
+    text: str,
+    output_dir: str | Path = "data/audio",
+    filename_stem: str = "response",
+    model: Optional[str] = None,
+    voice: Optional[str] = None,
+    command: Optional[str] = None,
+) -> Path:
+    """
+    Generate speech audio using Resemble's Chatterbox.
+
+    Provide one of:
+    - command: a CLI command template, e.g. "chatterbox --text {text} --out {out}"
+    - a Python package import with a callable "synthesize" API
+    """
+    output_path = _ensure_output_path(Path(output_dir), filename_stem)
+
+    if command:
+        formatted = command.format(text=text, out=str(output_path), model=model or "", voice=voice or "")
+        subprocess.run(shlex.split(formatted), check=True)
+        return output_path
+
+    try:
+        chatterbox = importlib.import_module("chatterbox")
+    except ModuleNotFoundError as exc:
+        raise RuntimeError(
+            "Chatterbox is not installed. Install it from https://github.com/resemble-ai/chatterbox "
+            "or pass a CLI command via --tts-cmd."
+        ) from exc
+
+    if hasattr(chatterbox, "synthesize"):
+        chatterbox.synthesize(
+            text=text,
+            output_path=str(output_path),
+            model=model,
+            voice=voice,
+        )
+        return output_path
+
+    raise RuntimeError(
+        "Chatterbox import succeeded but no compatible API was found. "
+        "Provide a CLI command via --tts-cmd."
+    )


### PR DESCRIPTION
### Motivation
- Enable routing of customer queries to specialist agents (billing, account, transaction, complaint, general) and combine specialist outputs into synthesized replies.  
- Capture richer per-interaction metadata for later analysis and dashboards.  
- Provide utilities for retrieval grounding and synthetic query generation to support grounded and load/testing scenarios.  
- Add optional voice output (TTS) and CLI flags so simulations and demos can emit audio and produce session-linked logs.  

### Description
- Added `router.py` to perform rule-based or LLM-based routing and wired a `run_routed_support_flow` into `base_agents.py` which uses `retrieve_context` to inject grounding.  
- Added `metrics.py` to aggregate JSONL logs, `retrieval.py` to load the FAQ DB, and `synthetic_data.py` to generate test queries, plus updated `simulation_engine.py` and `base_agents.py` to include `session_id` and routing flags.  
- Extended logging by changing `memory.log_interaction` to accept a `metadata` dict and updated `sim_agents.py` to merge timing/cost info into metadata before persisting.  
- Added a TTS hook at `voice/tts.py` (supports a CLI command template or an importable `chatterbox.synthesize`), updated `main.py` to expose CLI flags for routing, session id, TTS, and metrics, and wired voice logging to the JSONL logs.  

### Testing
- No automated tests were executed as part of this change.  
- The change was committed locally and basic file-level consistency checks (file creation/patch application) completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69557ec7a050832aa241db4de371bc77)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a specialist‑routed support path and richer observability/UX across the simulator.
> 
> - New `run_routed_support_flow` using `router.py` (rule‑based or LLM) to pick specialists, injects FAQ context via `retrieve_context`, and synthesizes a unified reply
> - Extends `TaskAwareAgent/GroupChat` to accept `context` and persist timing/cost `metadata`; `memory.log_interaction` now records arbitrary `metadata`
> - New `metrics.py` to aggregate JSONL logs (AHT, cost, escalations, task breakdown) and `synthetic_data.py` to generate test queries
> - CLI updates in `main.py`: modes (`cli|batch|synthetic`), router flags, `session_id`, metrics printout, and optional TTS output via `voice/tts.py` (Chatterbox or command template)
> - Wires `session_id`/route metadata throughout `base_agents.py` and `simulation_engine.py` for end‑to‑end logging
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ac85756c11b8dd3ff75a8840ad479ffc280d41c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->